### PR TITLE
Specify where enabled rules are coming from in debug output

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -21,6 +21,20 @@ func TestNewConfig(t *testing.T) {
 		log.Logger = zerolog.New(out)
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)
 
+		// isolate config rules
+		loaded, err := loadConfig("testdata/good.yaml")
+		assert.NoError(t, err)
+		configRules := make([]string, len(loaded.Rules))
+		for i := range loaded.Rules {
+			configRules[i] = fmt.Sprintf("%q", loaded.Rules[i].Name)
+		}
+
+		// isolate default rules
+		defaultRules := make([]string, len(rule.DefaultRules))
+		for i := range defaultRules {
+			defaultRules[i] = fmt.Sprintf("%q", rule.DefaultRules[i].Name)
+		}
+
 		c, err := NewConfig("testdata/good.yaml")
 		assert.NoError(t, err)
 		enabledRules := make([]string, len(c.Rules))
@@ -28,8 +42,12 @@ func TestNewConfig(t *testing.T) {
 			enabledRules[i] = fmt.Sprintf("%q", c.Rules[i].Name)
 		}
 
+		loadedConfigMsg := `{"level":"debug","config":"testdata/good.yaml","message":"loaded config file"}`
+		configRulesMsg := fmt.Sprintf(`{"level":"debug","rules":[%s],"message":"config rules enabled"}`, strings.Join(configRules, ","))
+		defaultRulesMsg := fmt.Sprintf(`{"level":"debug","rules":[%s],"message":"default rules enabled"}`, strings.Join(defaultRules, ","))
+		allRulesMsg := fmt.Sprintf(`{"level":"debug","rules":[%s],"message":"all rules enabled"}`, strings.Join(enabledRules, ","))
 		assert.Equal(t,
-			fmt.Sprintf(`{"level":"debug","config":"testdata/good.yaml","message":"loaded config file"}`+"\n"+`{"level":"debug","rules":[%s],"message":"rules enabled"}`, strings.Join(enabledRules, ","))+"\n",
+			loadedConfigMsg+"\n"+configRulesMsg+"\n"+defaultRulesMsg+"\n"+allRulesMsg+"\n",
 			out.String())
 	})
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/get-woke/woke/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Debug output enriched to display where the enabled rules are coming from (i.e. which rules are config, which rules are default).


**What is the current behavior?** (You can also link to an open issue here)
Current behavior is to just show all enabled rules in one debug message without differentiation. 


**What is the new behavior (if this is a feature change)?**
If config file is loaded:
- logs loaded config file as normal
- logs all config rules enabled (with config label)
- logs all default rules enabled (with default label)
- logs all combined enabled rules (with all label)

if no config file is loaded:
- logs "no config file loaded, using only default rules"
- logs all default rules enabled (with default label)
- logs all combined enabled rules (with all label)


**Does this PR introduce a breaking change?** (What changes might users need to make due to this PR?)
No breaking changes

**Other information**:
