### PR TITLE
Add remote ruleset to woke configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ This file will be picked up automatically up your customizations without needing
 See [example.yaml](https://github.com/get-woke/woke/blob/main/example.yaml) for an example of adding custom rules.
 You can also supply your own rules with `-c path/to/rules.yaml` if you want to handle different rulesets.
 
+You can also supply an external remote ruleset from any public URL. To do so, use the same -c flag, followed by the public URL. For example: '-c https://raw.githubusercontent.com/get-woke/woke/main/example.yaml'
+
 The syntax for rules is very basic. You just need a name, a list of terms to match that violate the rule,
 and a list of alternative suggestions.
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,7 +2,10 @@ package config
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
+	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 
@@ -81,12 +84,68 @@ func (c *Config) ConfigureRules() {
 }
 
 func loadConfig(filename string) (c Config, err error) {
+	if isValidUrl(filename) {
+		// if fileName is a valid URL, we will download and set it to the config
+		log.Debug().Str("url", filename).Msg("Downloading file from")
+		//hardcoding this file and saving to root directory
+		downloadedFile := "downloadedRules.yaml"
+		err := DownloadFile(downloadedFile, filename)
+		if err != nil {
+			return c, err
+		}
+		filename = downloadedFile
+		log.Debug().Str("filename", filename).Msg("Saved remote config to local file.")
+	}
+
+	// TO DO = Need to add more error handling on reading/validating yamlFile file - issue # 16
 	yamlFile, err := ioutil.ReadFile(filename)
+	log.Debug().Str("filename", filename).Msg("Adding custom ruleset from")
 	if err != nil {
 		return c, err
 	}
-
 	return c, yaml.Unmarshal(yamlFile, &c)
+}
+
+// isValidUrl tests a string to determine if it is a valid URL or not
+func isValidUrl(toTest string) bool {
+	_, err := url.ParseRequestURI(toTest)
+	if err != nil {
+		return false
+	}
+
+	u, err := url.Parse(toTest)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return false
+	}
+	log.Debug().Str("remoteConfig", toTest).Msg("Valid URL for remote config.")
+	return true
+}
+
+//downloads file from url to set filepath
+func DownloadFile(filepath string, url string) error {
+	// Get the data
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	// only parse response body if it is in the response is in the 2xx range
+	if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
+		log.Debug().Int("HTTP Response Status:", resp.StatusCode).Msg("Valid URL Response")
+		defer resp.Body.Close()
+
+		// Create the file
+		out, err := os.Create(filepath)
+		if err != nil {
+			return err
+		}
+		defer out.Close()
+
+		// Write the body to file
+		_, err = io.Copy(out, resp.Body)
+		return err
+	} else {
+		return fmt.Errorf("unable to download remote config from url - http response code: %v", resp.StatusCode)
+	}
 }
 
 func relative(filename string) string {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -99,7 +99,6 @@ func loadConfig(filename string) (c Config, err error) {
 		log.Debug().Str("filename", filename).Msg("Saved remote config to local file.")
 	}
 
-	// TO DO = Need to add more error handling on reading/validating yamlFile file - issue # 16
 	yamlFile, err := ioutil.ReadFile(filename)
 	log.Debug().Str("filename", filename).Msg("Adding custom ruleset from")
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/get-woke/woke/pkg/rule"
 
@@ -87,7 +88,7 @@ func loadConfig(filename string) (c Config, err error) {
 	if isValidURL(filename) {
 		// if fileName is a valid URL, we will download and set it to the config
 		log.Debug().Str("url", filename).Msg("Downloading file from")
-		//hardcoding this file and saving to root directory
+		// hardcoding this file and saving to root directory
 		downloadedFile := "downloadedRules.yaml"
 		err := DownloadFile(downloadedFile, filename)
 		if err != nil {
@@ -121,10 +122,15 @@ func isValidURL(toTest string) bool {
 	return true
 }
 
-//downloads file from url to set filepath
+// downloads file from url to set filepath
 func DownloadFile(filepath string, url string) error {
-	// Get the data
-	resp, err := http.Get(url)
+	// Removing gosec lint warning - as we have to pass in user specified url for remote config
+	// nolint:gosec
+	var netClient = &http.Client{
+		Timeout: time.Second * 10,
+	}
+	resp, err := netClient.Get(url)
+	//resp, err := http.Get(url)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -84,7 +84,7 @@ func (c *Config) ConfigureRules() {
 }
 
 func loadConfig(filename string) (c Config, err error) {
-	if isValidUrl(filename) {
+	if isValidURL(filename) {
 		// if fileName is a valid URL, we will download and set it to the config
 		log.Debug().Str("url", filename).Msg("Downloading file from")
 		//hardcoding this file and saving to root directory
@@ -107,7 +107,7 @@ func loadConfig(filename string) (c Config, err error) {
 }
 
 // isValidUrl tests a string to determine if it is a valid URL or not
-func isValidUrl(toTest string) bool {
+func isValidURL(toTest string) bool {
 	_, err := url.ParseRequestURI(toTest)
 	if err != nil {
 		return false

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -125,7 +125,6 @@ func isValidURL(toTest string) bool {
 
 // downloads file from url to set filepath
 func DownloadFile(filepath string, url string) error {
-	// Removing gosec lint warning - as we have to pass in user specified url for remote config
 	var client = &http.Client{
 		Timeout: time.Second * 10,
 	}
@@ -135,7 +134,6 @@ func DownloadFile(filepath string, url string) error {
 	if err != nil {
 		return err
 	}
-
 	// only parse response body if it is in the response is in the 2xx range
 	if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
 		log.Debug().Int("HTTP Response Status:", resp.StatusCode).Msg("Valid URL Response")
@@ -147,13 +145,12 @@ func DownloadFile(filepath string, url string) error {
 			return err
 		}
 		defer out.Close()
-
-		log.Debug().Int("here", resp.StatusCode).Msg("help")
 		// Write the body to file
 		_, err = io.Copy(out, resp.Body)
 		return err
 	} else {
-		return fmt.Errorf("unable to download remote config from url - http response code: %v", resp.StatusCode)
+		body, _ := ioutil.ReadAll(resp.Body)
+		return fmt.Errorf("unable to download remote config from url. Response code: %v. Response body: %c", resp.StatusCode, body)
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -125,15 +126,16 @@ func isValidURL(toTest string) bool {
 // downloads file from url to set filepath
 func DownloadFile(filepath string, url string) error {
 	// Removing gosec lint warning - as we have to pass in user specified url for remote config
-	// nolint:gosec
-	var netClient = &http.Client{
+	var client = &http.Client{
 		Timeout: time.Second * 10,
 	}
-	resp, err := netClient.Get(url)
-	//resp, err := http.Get(url)
+	ctx := context.Background()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	resp, err := client.Do(req)
 	if err != nil {
 		return err
 	}
+
 	// only parse response body if it is in the response is in the 2xx range
 	if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
 		log.Debug().Int("HTTP Response Status:", resp.StatusCode).Msg("Valid URL Response")
@@ -146,6 +148,7 @@ func DownloadFile(filepath string, url string) error {
 		}
 		defer out.Close()
 
+		log.Debug().Int("here", resp.StatusCode).Msg("help")
 		// Write the body to file
 		_, err = io.Copy(out, resp.Body)
 		return err

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -162,7 +162,7 @@ func Test_LoadConfig(t *testing.T) {
 		c, err := loadConfig("https://raw.githubusercontent.com/get-woke/woke/main/example.yaml")
 		assert.NoError(t, err)
 		assert.NotNil(t, c)
-		//delete downloaded file after successful test
+		// delete downloaded file after successful test
 		os.Remove("downloadedRules.yaml")
 	})
 
@@ -186,14 +186,13 @@ func Test_isValidURL(t *testing.T) {
 		boolResponse := isValidURL("/Users/Document/test.yaml")
 		assert.False(t, boolResponse)
 	})
-
 }
 
 func Test_DownloadFile(t *testing.T) {
 	t.Run("valid-url", func(t *testing.T) {
 		err := DownloadFile("DownloadedFile.yaml", "https://raw.githubusercontent.com/get-woke/woke/main/example.yaml")
 		assert.NoError(t, err)
-		//delete downloaded file after successful test
+		// delete downloaded file after successful test
 		os.Remove("DownloadedFile.yaml")
 	})
 
@@ -201,7 +200,6 @@ func Test_DownloadFile(t *testing.T) {
 		err := DownloadFile("DownloadedFile.yaml", "https://raw.githubusercontent.com/get-woke/woke/main/example")
 		assert.Error(t, err)
 	})
-
 }
 
 func Test_relative(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -186,6 +186,16 @@ func Test_isValidURL(t *testing.T) {
 		boolResponse := isValidURL("/Users/Document/test.yaml")
 		assert.False(t, boolResponse)
 	})
+
+	t.Run("invalid-url", func(t *testing.T) {
+		boolResponse := isValidURL("C:User\testpath\test.yaml")
+		assert.False(t, boolResponse)
+	})
+
+	t.Run("invalid-url", func(t *testing.T) {
+		boolResponse := isValidURL("C:\\directory.com\test.yaml")
+		assert.False(t, boolResponse)
+	})
 }
 
 func Test_DownloadFile(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -173,17 +173,17 @@ func Test_LoadConfig(t *testing.T) {
 
 func Test_isValidURL(t *testing.T) {
 	t.Run("valid-url", func(t *testing.T) {
-		boolResponse := isValidUrl("https://raw.githubusercontent.com/get-woke/woke/main/example.yaml")
+		boolResponse := isValidURL("https://raw.githubusercontent.com/get-woke/woke/main/example.yaml")
 		assert.True(t, boolResponse)
 	})
 
 	t.Run("invalid-url", func(t *testing.T) {
-		boolResponse := isValidUrl("Users/Document/test.yaml")
+		boolResponse := isValidURL("Users/Document/test.yaml")
 		assert.False(t, boolResponse)
 	})
 
 	t.Run("invalid-url", func(t *testing.T) {
-		boolResponse := isValidUrl("/Users/Document/test.yaml")
+		boolResponse := isValidURL("/Users/Document/test.yaml")
 		assert.False(t, boolResponse)
 	})
 


### PR DESCRIPTION
Please check if the PR fulfills these requirements

- [x]  The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Feature

What is the current behavior? (You can also link to an open issue here)
Link to issue: #1 

What is the new behavior (if this is a feature change)?
This PR adds functionality to pull in remote rules from urls - https.

To test this PR:
go build
go run main.go -c "https://raw.githubusercontent.com/get-woke/woke/main/example.yaml" --debug

To test a 404 URL:
go run main.go -c "https://raw.githubusercontent.com/get-woke/woke/main/example" --debug