### PR TITLE
Revert "Add remote ruleset to woke configuration"

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,6 @@ This file will be picked up automatically up your customizations without needing
 See [example.yaml](https://github.com/get-woke/woke/blob/main/example.yaml) for an example of adding custom rules.
 You can also supply your own rules with `-c path/to/rules.yaml` if you want to handle different rulesets.
 
-You can also supply an external remote ruleset from any public URL. To do so, use the same -c flag, followed by the public URL. For example: '-c https://raw.githubusercontent.com/get-woke/woke/main/example.yaml'
-
 The syntax for rules is very basic. You just need a name, a list of terms to match that violate the rule,
 and a list of alternative suggestions.
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,15 +1,10 @@
 package config
 
 import (
-	"context"
 	"fmt"
-	"io"
 	"io/ioutil"
-	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/get-woke/woke/pkg/rule"
 
@@ -88,71 +83,12 @@ func (c *Config) ConfigureRules() {
 }
 
 func loadConfig(filename string) (c Config, err error) {
-	if isValidURL(filename) {
-		// if fileName is a valid URL, we will download and set it to the config
-		log.Debug().Str("url", filename).Msg("Downloading file from")
-		// hardcoding this file and saving to root directory
-		downloadedFile := "downloadedRules.yaml"
-		err := DownloadFile(downloadedFile, filename)
-		if err != nil {
-			return c, err
-		}
-		filename = downloadedFile
-		log.Debug().Str("filename", filename).Msg("Saved remote config to local file.")
-	}
-
 	yamlFile, err := ioutil.ReadFile(filename)
-	log.Debug().Str("filename", filename).Msg("Adding custom ruleset from")
 	if err != nil {
 		return c, err
 	}
+
 	return c, yaml.Unmarshal(yamlFile, &c)
-}
-
-// isValidUrl tests a string to determine if it is a valid URL or not
-func isValidURL(toTest string) bool {
-	_, err := url.ParseRequestURI(toTest)
-	if err != nil {
-		return false
-	}
-
-	u, err := url.Parse(toTest)
-	if err != nil || u.Scheme == "" || u.Host == "" {
-		return false
-	}
-	log.Debug().Str("remoteConfig", toTest).Msg("Valid URL for remote config.")
-	return true
-}
-
-// downloads file from url to set filepath
-func DownloadFile(filepath string, url string) error {
-	var client = &http.Client{
-		Timeout: time.Second * 10,
-	}
-	ctx := context.Background()
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	// only parse response body if it is in the response is in the 2xx range
-	if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
-		log.Debug().Int("HTTP Response Status:", resp.StatusCode).Msg("Valid URL Response")
-		defer resp.Body.Close()
-
-		// Create the file
-		out, err := os.Create(filepath)
-		if err != nil {
-			return err
-		}
-		defer out.Close()
-		// Write the body to file
-		_, err = io.Copy(out, resp.Body)
-		return err
-	} else {
-		body, _ := ioutil.ReadAll(resp.Body)
-		return fmt.Errorf("unable to download remote config from url. Response code: %v. Response body: %c", resp.StatusCode, body)
-	}
 }
 
 func relative(filename string) string {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -42,14 +42,12 @@ func TestNewConfig(t *testing.T) {
 			enabledRules[i] = fmt.Sprintf("%q", c.Rules[i].Name)
 		}
 
-		loadedRemoteConfigMsg := `{"level":"debug","filename":"testdata/good.yaml","message":"Adding custom ruleset from"}`
-		loadedRemoteConfig := `{"level":"debug","filename":"testdata/good.yaml","message":"Adding custom ruleset from"}`
 		loadedConfigMsg := `{"level":"debug","config":"testdata/good.yaml","message":"loaded config file"}`
 		configRulesMsg := fmt.Sprintf(`{"level":"debug","rules":[%s],"message":"config rules enabled"}`, strings.Join(configRules, ","))
 		defaultRulesMsg := fmt.Sprintf(`{"level":"debug","rules":[%s],"message":"default rules enabled"}`, strings.Join(defaultRules, ","))
 		allRulesMsg := fmt.Sprintf(`{"level":"debug","rules":[%s],"message":"all rules enabled"}`, strings.Join(enabledRules, ","))
 		assert.Equal(t,
-			loadedRemoteConfigMsg+"\n"+loadedRemoteConfig+"\n"+loadedConfigMsg+"\n"+configRulesMsg+"\n"+defaultRulesMsg+"\n"+allRulesMsg+"\n",
+			loadedConfigMsg+"\n"+configRulesMsg+"\n"+defaultRulesMsg+"\n"+allRulesMsg+"\n",
 			out.String())
 	})
 
@@ -154,61 +152,6 @@ func TestNewConfig(t *testing.T) {
 
 		// check IncludeNote is not overridden for rule1
 		assert.Equal(t, true, *c.Rules[0].Options.IncludeNote)
-	})
-}
-
-func Test_LoadConfig(t *testing.T) {
-	t.Run("valid-url", func(t *testing.T) {
-		c, err := loadConfig("https://raw.githubusercontent.com/get-woke/woke/main/example.yaml")
-		assert.NoError(t, err)
-		assert.NotNil(t, c)
-		// delete downloaded file after successful test
-		os.Remove("downloadedRules.yaml")
-	})
-
-	t.Run("invalid-url", func(t *testing.T) {})
-	_, err := loadConfig("https://raw.githubusercontent.com/get-woke/woke/main/example")
-	assert.Error(t, err)
-}
-
-func Test_isValidURL(t *testing.T) {
-	t.Run("valid-url", func(t *testing.T) {
-		boolResponse := isValidURL("https://raw.githubusercontent.com/get-woke/woke/main/example.yaml")
-		assert.True(t, boolResponse)
-	})
-
-	t.Run("invalid-url", func(t *testing.T) {
-		boolResponse := isValidURL("Users/Document/test.yaml")
-		assert.False(t, boolResponse)
-	})
-
-	t.Run("invalid-url", func(t *testing.T) {
-		boolResponse := isValidURL("/Users/Document/test.yaml")
-		assert.False(t, boolResponse)
-	})
-
-	t.Run("invalid-url", func(t *testing.T) {
-		boolResponse := isValidURL("C:User\testpath\test.yaml")
-		assert.False(t, boolResponse)
-	})
-
-	t.Run("invalid-url", func(t *testing.T) {
-		boolResponse := isValidURL("C:\\directory.com\test.yaml")
-		assert.False(t, boolResponse)
-	})
-}
-
-func Test_DownloadFile(t *testing.T) {
-	t.Run("valid-url", func(t *testing.T) {
-		err := DownloadFile("DownloadedFile.yaml", "https://raw.githubusercontent.com/get-woke/woke/main/example.yaml")
-		assert.NoError(t, err)
-		// delete downloaded file after successful test
-		os.Remove("DownloadedFile.yaml")
-	})
-
-	t.Run("invalid-url", func(t *testing.T) {
-		err := DownloadFile("DownloadedFile.yaml", "https://raw.githubusercontent.com/get-woke/woke/main/example")
-		assert.Error(t, err)
 	})
 }
 


### PR DESCRIPTION
Reverts inclusive-dev-tools/woke#28

Did not mean to merge into forked main. Following our gitflow, this feature will be merged into forked main AFTER it is merged into get-woke/main. Submitted PR to get-woke repo 